### PR TITLE
Update aws_c_iot_jll to version 0.2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsIot"
 uuid = "d022c788-31c6-4e56-9a35-f63e7e4f3ca1"
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -23,7 +23,7 @@ LibAwsHTTP = "1"
 LibAwsIO = "1"
 LibAwsMqtt = "1"
 LibAwsSdkutils = "1"
-aws_c_iot_jll = "=0.1.21"
+aws_c_iot_jll = "=0.2.1"
 julia = "1.6"
 
 [extras]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -20,4 +20,4 @@ aws_c_sdkutils_jll = "1282aa60-004d-510b-9f52-12498d409daa"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_c_iot_jll = "=0.1.21"
+aws_c_iot_jll = "=0.2.1"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    __JL_Ctag_80
+    union (unnamed at /home/runner/.julia/artifacts/f0ceef6c683b6b7af5fd02481accb32f8bac0486/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_80
+struct var"union (unnamed at /home/runner/.julia/artifacts/f0ceef6c683b6b7af5fd02481accb32f8bac0486/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_80}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f0ceef6c683b6b7af5fd02481accb32f8bac0486/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_80, f::Symbol)
-    r = Ref{__JL_Ctag_80}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_80}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f0ceef6c683b6b7af5fd02481accb32f8bac0486/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f0ceef6c683b6b7af5fd02481accb32f8bac0486/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f0ceef6c683b6b7af5fd02481accb32f8bac0486/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_80}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f0ceef6c683b6b7af5fd02481accb32f8bac0486/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -468,6 +468,7 @@ Documentation not found.
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_NO_ACTIVE_CONNECTION = 13338
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_PROTOCOL_VERSION_MISMATCH = 13339
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_INACTIVE_SERVICE_ID = 13340
+    AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_ENCODE_FAILURE = 13341
     AWS_ERROR_END_IOTDEVICE_RANGE = 14335
 end
 

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    __JL_Ctag_210
+    union (unnamed at /home/runner/.julia/artifacts/c43d1b14ea89949dc0fbeb710b3daebe7e1f6fc0/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_210
+struct var"union (unnamed at /home/runner/.julia/artifacts/c43d1b14ea89949dc0fbeb710b3daebe7e1f6fc0/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_210}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c43d1b14ea89949dc0fbeb710b3daebe7e1f6fc0/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_210, f::Symbol)
-    r = Ref{__JL_Ctag_210}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_210}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/c43d1b14ea89949dc0fbeb710b3daebe7e1f6fc0/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/c43d1b14ea89949dc0fbeb710b3daebe7e1f6fc0/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c43d1b14ea89949dc0fbeb710b3daebe7e1f6fc0/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_210}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/c43d1b14ea89949dc0fbeb710b3daebe7e1f6fc0/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -468,6 +468,7 @@ Documentation not found.
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_NO_ACTIVE_CONNECTION = 13338
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_PROTOCOL_VERSION_MISMATCH = 13339
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_INACTIVE_SERVICE_ID = 13340
+    AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_ENCODE_FAILURE = 13341
     AWS_ERROR_END_IOTDEVICE_RANGE = 14335
 end
 

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    __JL_Ctag_90
+    union (unnamed at /home/runner/.julia/artifacts/1279320997439476831fdb6a9fa0cf3d50ab2449/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_90
+struct var"union (unnamed at /home/runner/.julia/artifacts/1279320997439476831fdb6a9fa0cf3d50ab2449/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_90}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1279320997439476831fdb6a9fa0cf3d50ab2449/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_90, f::Symbol)
-    r = Ref{__JL_Ctag_90}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_90}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/1279320997439476831fdb6a9fa0cf3d50ab2449/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/1279320997439476831fdb6a9fa0cf3d50ab2449/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1279320997439476831fdb6a9fa0cf3d50ab2449/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_90}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/1279320997439476831fdb6a9fa0cf3d50ab2449/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -468,6 +468,7 @@ Documentation not found.
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_NO_ACTIVE_CONNECTION = 13338
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_PROTOCOL_VERSION_MISMATCH = 13339
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_INACTIVE_SERVICE_ID = 13340
+    AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_ENCODE_FAILURE = 13341
     AWS_ERROR_END_IOTDEVICE_RANGE = 14335
 end
 

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    __JL_Ctag_210
+    union (unnamed at /home/runner/.julia/artifacts/13da41cb1caa00de91afac7c7727994e400aedc6/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_210
+struct var"union (unnamed at /home/runner/.julia/artifacts/13da41cb1caa00de91afac7c7727994e400aedc6/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_210}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/13da41cb1caa00de91afac7c7727994e400aedc6/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_210, f::Symbol)
-    r = Ref{__JL_Ctag_210}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_210}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/13da41cb1caa00de91afac7c7727994e400aedc6/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/13da41cb1caa00de91afac7c7727994e400aedc6/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/13da41cb1caa00de91afac7c7727994e400aedc6/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_210}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/13da41cb1caa00de91afac7c7727994e400aedc6/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -468,6 +468,7 @@ Documentation not found.
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_NO_ACTIVE_CONNECTION = 13338
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_PROTOCOL_VERSION_MISMATCH = 13339
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_INACTIVE_SERVICE_ID = 13340
+    AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_ENCODE_FAILURE = 13341
     AWS_ERROR_END_IOTDEVICE_RANGE = 14335
 end
 

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    __JL_Ctag_90
+    union (unnamed at /home/runner/.julia/artifacts/b91a6bfd63485ba689a109ec4b3c21be0b7c2b9c/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_90
+struct var"union (unnamed at /home/runner/.julia/artifacts/b91a6bfd63485ba689a109ec4b3c21be0b7c2b9c/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_90}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b91a6bfd63485ba689a109ec4b3c21be0b7c2b9c/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_90, f::Symbol)
-    r = Ref{__JL_Ctag_90}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_90}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/b91a6bfd63485ba689a109ec4b3c21be0b7c2b9c/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/b91a6bfd63485ba689a109ec4b3c21be0b7c2b9c/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b91a6bfd63485ba689a109ec4b3c21be0b7c2b9c/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_90}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/b91a6bfd63485ba689a109ec4b3c21be0b7c2b9c/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -468,6 +468,7 @@ Documentation not found.
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_NO_ACTIVE_CONNECTION = 13338
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_PROTOCOL_VERSION_MISMATCH = 13339
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_INACTIVE_SERVICE_ID = 13340
+    AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_ENCODE_FAILURE = 13341
     AWS_ERROR_END_IOTDEVICE_RANGE = 14335
 end
 

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    __JL_Ctag_205
+    union (unnamed at /home/runner/.julia/artifacts/13eaa38fad83e0d114b6a75626ddcf60825c9a35/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_205
+struct var"union (unnamed at /home/runner/.julia/artifacts/13eaa38fad83e0d114b6a75626ddcf60825c9a35/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_205}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/13eaa38fad83e0d114b6a75626ddcf60825c9a35/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_205, f::Symbol)
-    r = Ref{__JL_Ctag_205}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_205}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/13eaa38fad83e0d114b6a75626ddcf60825c9a35/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/13eaa38fad83e0d114b6a75626ddcf60825c9a35/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/13eaa38fad83e0d114b6a75626ddcf60825c9a35/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_205}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/13eaa38fad83e0d114b6a75626ddcf60825c9a35/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -468,6 +468,7 @@ Documentation not found.
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_NO_ACTIVE_CONNECTION = 13338
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_PROTOCOL_VERSION_MISMATCH = 13339
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_INACTIVE_SERVICE_ID = 13340
+    AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_ENCODE_FAILURE = 13341
     AWS_ERROR_END_IOTDEVICE_RANGE = 14335
 end
 

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    __JL_Ctag_90
+    union (unnamed at /home/runner/.julia/artifacts/8116734abaa2c190e7d9bc67f8ad02c0f883ba7d/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_90
+struct var"union (unnamed at /home/runner/.julia/artifacts/8116734abaa2c190e7d9bc67f8ad02c0f883ba7d/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{4, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_90}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8116734abaa2c190e7d9bc67f8ad02c0f883ba7d/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_90, f::Symbol)
-    r = Ref{__JL_Ctag_90}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_90}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/8116734abaa2c190e7d9bc67f8ad02c0f883ba7d/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/8116734abaa2c190e7d9bc67f8ad02c0f883ba7d/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8116734abaa2c190e7d9bc67f8ad02c0f883ba7d/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_90}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/8116734abaa2c190e7d9bc67f8ad02c0f883ba7d/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -468,6 +468,7 @@ Documentation not found.
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_NO_ACTIVE_CONNECTION = 13338
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_PROTOCOL_VERSION_MISMATCH = 13339
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_INACTIVE_SERVICE_ID = 13340
+    AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_ENCODE_FAILURE = 13341
     AWS_ERROR_END_IOTDEVICE_RANGE = 14335
 end
 

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    __JL_Ctag_205
+    union (unnamed at /home/runner/.julia/artifacts/9637e672af38fb7f89540f01d199d3930a898c6f/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_205
+struct var"union (unnamed at /home/runner/.julia/artifacts/9637e672af38fb7f89540f01d199d3930a898c6f/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_205}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9637e672af38fb7f89540f01d199d3930a898c6f/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_205, f::Symbol)
-    r = Ref{__JL_Ctag_205}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_205}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/9637e672af38fb7f89540f01d199d3930a898c6f/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/9637e672af38fb7f89540f01d199d3930a898c6f/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9637e672af38fb7f89540f01d199d3930a898c6f/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_205}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/9637e672af38fb7f89540f01d199d3930a898c6f/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -468,6 +468,7 @@ Documentation not found.
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_NO_ACTIVE_CONNECTION = 13338
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_PROTOCOL_VERSION_MISMATCH = 13339
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_INACTIVE_SERVICE_ID = 13340
+    AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_ENCODE_FAILURE = 13341
     AWS_ERROR_END_IOTDEVICE_RANGE = 14335
 end
 

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    __JL_Ctag_80
+    union (unnamed at /home/runner/.julia/artifacts/442cfd5b8c0d9e10bd44be4da87c679f1eab0c5a/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_80
+struct var"union (unnamed at /home/runner/.julia/artifacts/442cfd5b8c0d9e10bd44be4da87c679f1eab0c5a/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_80}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/442cfd5b8c0d9e10bd44be4da87c679f1eab0c5a/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_80, f::Symbol)
-    r = Ref{__JL_Ctag_80}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_80}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/442cfd5b8c0d9e10bd44be4da87c679f1eab0c5a/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/442cfd5b8c0d9e10bd44be4da87c679f1eab0c5a/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/442cfd5b8c0d9e10bd44be4da87c679f1eab0c5a/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_80}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/442cfd5b8c0d9e10bd44be4da87c679f1eab0c5a/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -468,6 +468,7 @@ Documentation not found.
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_NO_ACTIVE_CONNECTION = 13338
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_PROTOCOL_VERSION_MISMATCH = 13339
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_INACTIVE_SERVICE_ID = 13340
+    AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_ENCODE_FAILURE = 13341
     AWS_ERROR_END_IOTDEVICE_RANGE = 14335
 end
 

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1,31 +1,5 @@
 using CEnum
 
-"""
-    __JL_Ctag_205
-
-Documentation not found.
-"""
-struct __JL_Ctag_205
-    data::NTuple{8, UInt8}
-end
-
-function Base.getproperty(x::Ptr{__JL_Ctag_205}, f::Symbol)
-    f === :scheduled && return Ptr{Bool}(x + 0)
-    f === :reserved && return Ptr{Csize_t}(x + 0)
-    return getfield(x, f)
-end
-
-function Base.getproperty(x::__JL_Ctag_205, f::Symbol)
-    r = Ref{__JL_Ctag_205}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_205}, r)
-    fptr = getproperty(ptr, f)
-    GC.@preserve r unsafe_load(fptr)
-end
-
-function Base.setproperty!(x::Ptr{__JL_Ctag_205}, f::Symbol, v)
-    unsafe_store!(getproperty(x, f), v)
-end
-
 # typedef int ( aws_iotdevice_defender_publish_fn ) ( struct aws_byte_cursor report , void * userdata )
 """
 Callback to invoke when the defender task needs to "publish" a report. Useful to override default MQTT publish behavior, for testing report outputs
@@ -468,6 +442,7 @@ Documentation not found.
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_NO_ACTIVE_CONNECTION = 13338
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_PROTOCOL_VERSION_MISMATCH = 13339
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_INACTIVE_SERVICE_ID = 13340
+    AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_ENCODE_FAILURE = 13341
     AWS_ERROR_END_IOTDEVICE_RANGE = 14335
 end
 

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    __JL_Ctag_90
+    union (unnamed at /home/runner/.julia/artifacts/d4dbc10dce10146e1fc50ee330c63e08f5d0150e/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_90
+struct var"union (unnamed at /home/runner/.julia/artifacts/d4dbc10dce10146e1fc50ee330c63e08f5d0150e/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_90}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d4dbc10dce10146e1fc50ee330c63e08f5d0150e/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_90, f::Symbol)
-    r = Ref{__JL_Ctag_90}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_90}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/d4dbc10dce10146e1fc50ee330c63e08f5d0150e/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/d4dbc10dce10146e1fc50ee330c63e08f5d0150e/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d4dbc10dce10146e1fc50ee330c63e08f5d0150e/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_90}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/d4dbc10dce10146e1fc50ee330c63e08f5d0150e/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -468,6 +468,7 @@ Documentation not found.
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_NO_ACTIVE_CONNECTION = 13338
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_PROTOCOL_VERSION_MISMATCH = 13339
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_INACTIVE_SERVICE_ID = 13340
+    AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_ENCODE_FAILURE = 13341
     AWS_ERROR_END_IOTDEVICE_RANGE = 14335
 end
 

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    __JL_Ctag_70
+    union (unnamed at /home/runner/.julia/artifacts/944142396341a55bdeec61978320842846468a7c/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_70
+struct var"union (unnamed at /home/runner/.julia/artifacts/944142396341a55bdeec61978320842846468a7c/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_70}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/944142396341a55bdeec61978320842846468a7c/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_70, f::Symbol)
-    r = Ref{__JL_Ctag_70}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_70}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/944142396341a55bdeec61978320842846468a7c/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/944142396341a55bdeec61978320842846468a7c/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/944142396341a55bdeec61978320842846468a7c/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_70}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/944142396341a55bdeec61978320842846468a7c/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -468,6 +468,7 @@ Documentation not found.
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_NO_ACTIVE_CONNECTION = 13338
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_PROTOCOL_VERSION_MISMATCH = 13339
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_INACTIVE_SERVICE_ID = 13340
+    AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_ENCODE_FAILURE = 13341
     AWS_ERROR_END_IOTDEVICE_RANGE = 14335
 end
 

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1,28 +1,28 @@
 using CEnum
 
 """
-    __JL_Ctag_60
+    union (unnamed at /home/runner/.julia/artifacts/f91e217c8008d4d0a73d5d6f460e778246f9ec6b/include/aws/common/task_scheduler.h:40:5)
 
 Documentation not found.
 """
-struct __JL_Ctag_60
+struct var"union (unnamed at /home/runner/.julia/artifacts/f91e217c8008d4d0a73d5d6f460e778246f9ec6b/include/aws/common/task_scheduler.h:40:5)"
     data::NTuple{8, UInt8}
 end
 
-function Base.getproperty(x::Ptr{__JL_Ctag_60}, f::Symbol)
+function Base.getproperty(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f91e217c8008d4d0a73d5d6f460e778246f9ec6b/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol)
     f === :scheduled && return Ptr{Bool}(x + 0)
     f === :reserved && return Ptr{Csize_t}(x + 0)
     return getfield(x, f)
 end
 
-function Base.getproperty(x::__JL_Ctag_60, f::Symbol)
-    r = Ref{__JL_Ctag_60}(x)
-    ptr = Base.unsafe_convert(Ptr{__JL_Ctag_60}, r)
+function Base.getproperty(x::var"union (unnamed at /home/runner/.julia/artifacts/f91e217c8008d4d0a73d5d6f460e778246f9ec6b/include/aws/common/task_scheduler.h:40:5)", f::Symbol)
+    r = Ref{var"union (unnamed at /home/runner/.julia/artifacts/f91e217c8008d4d0a73d5d6f460e778246f9ec6b/include/aws/common/task_scheduler.h:40:5)"}(x)
+    ptr = Base.unsafe_convert(Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f91e217c8008d4d0a73d5d6f460e778246f9ec6b/include/aws/common/task_scheduler.h:40:5)"}, r)
     fptr = getproperty(ptr, f)
     GC.@preserve r unsafe_load(fptr)
 end
 
-function Base.setproperty!(x::Ptr{__JL_Ctag_60}, f::Symbol, v)
+function Base.setproperty!(x::Ptr{var"union (unnamed at /home/runner/.julia/artifacts/f91e217c8008d4d0a73d5d6f460e778246f9ec6b/include/aws/common/task_scheduler.h:40:5)"}, f::Symbol, v)
     unsafe_store!(getproperty(x, f), v)
 end
 
@@ -468,6 +468,7 @@ Documentation not found.
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_NO_ACTIVE_CONNECTION = 13338
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_DATA_PROTOCOL_VERSION_MISMATCH = 13339
     AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_INACTIVE_SERVICE_ID = 13340
+    AWS_ERROR_IOTDEVICE_SECURE_TUNNELING_ENCODE_FAILURE = 13341
     AWS_ERROR_END_IOTDEVICE_RANGE = 14335
 end
 


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_c_iot_jll** to version **0.2.1**
- Updated **JuliaServices/LibAwsIot.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings